### PR TITLE
Add `burst_capacity_enabled`

### DIFF
--- a/r-cosmosdb.tf
+++ b/r-cosmosdb.tf
@@ -42,6 +42,8 @@ resource "azurerm_cosmosdb_account" "main" {
     }
   }
 
+  burst_capacity_enabled = var.burst_capacity_enabled
+
   ip_range_filter = var.allowed_cidrs
 
   public_network_access_enabled         = var.public_network_access_enabled

--- a/variables-cosmosdb.tf
+++ b/variables-cosmosdb.tf
@@ -42,6 +42,12 @@ EOD
   default     = []
 }
 
+variable "burst_capacity_enabled" {
+  description = "Enable burst capacity for this Cosmos DB account"
+  type = bool
+  default = false
+}
+
 variable "allowed_cidrs" {
   description = "CosmosDB Firewall Support: This value specifies the set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IP's for a given database account."
   type        = list(string)

--- a/variables-cosmosdb.tf
+++ b/variables-cosmosdb.tf
@@ -43,9 +43,9 @@ EOD
 }
 
 variable "burst_capacity_enabled" {
-  description = "Enable burst capacity for this Cosmos DB account"
-  type = bool
-  default = false
+  description = "Enable burst capacity for this Cosmos DB account."
+  type        = bool
+  default     = false
 }
 
 variable "allowed_cidrs" {


### PR DESCRIPTION
Fixes #7.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- Adds support for `burst_capacity_enabled` for `azurerm_cosmosdb_account`

@claranet/fr-azure-reviewers
